### PR TITLE
fix: use file descriptor 3 instead of `tty` when redirecting output t…

### DIFF
--- a/git-squash
+++ b/git-squash
@@ -225,11 +225,11 @@ commit() {
   local commit_opts=("$@")
 
   local editor="$(find_git_editor)"
-  local git_config=(-c "core.editor=>$(tty) $editor")
+  local git_config=(-c "core.editor=>&3 $editor")
 
   local commit_result
 
-  git "${git_config[@]}" commit "${commit_opts[@]}" >/dev/null
+  git "${git_config[@]}" commit "${commit_opts[@]}" 3>&1 >/dev/null
   commit_result=$?
 
   if [[ $commit_result -ne 0 ]]; then

--- a/lib/base-commands/revert-reapply.bash
+++ b/lib/base-commands/revert-reapply.bash
@@ -469,9 +469,9 @@ commit() {
   fi
 
   local editor="$(find_git_editor)"
-  local git_config=(-c "color.advice=always" -c "core.editor=>$(tty) $editor")
+  local git_config=(-c "color.advice=always" -c "core.editor=>&3 $editor")
 
-  git "${git_config[@]}" commit -m "$message" "${commit_opts[@]}" >/dev/null
+  git "${git_config[@]}" commit -m "$message" "${commit_opts[@]}" 3>&1 >/dev/null
   local commit_result=$?
 
   if [ $commit_result -ne 0 ]; then
@@ -532,13 +532,13 @@ do_revert_reapply() {
 
   local command_err
   local command_result
-  local git_config=(-c "color.advice=always" -c "core.editor=>$(tty) $editor")
+  local git_config=(-c "color.advice=always" -c "core.editor=>&3 $editor")
 
   if [ "$revert_reapply_action" == "$ACTION_REAPPLY" ] && should_decorate_messages; then
     git_config+=(-c "core.hooksPath=$REAPPLY_HOOKS_PATH")
   fi
 
-  command_err="$(git "${git_config[@]}" $git_command_name "${command_opts[@]}" ${commit_hashes[*]} 2>&1 >/dev/null)"
+  command_err="$(git "${git_config[@]}" $git_command_name "${command_opts[@]}" ${commit_hashes[*]} 3>&1 2>&1 >/dev/null)"
   command_result=$?
 
   skipped_commit_hashes=()
@@ -547,7 +547,7 @@ do_revert_reapply() {
     while [ $command_result -ne 0 ] && is_skippable; do
       todo=$(get_next_todo)
 
-      command_err="$(git "${git_config[@]}" $git_command_name --skip "${command_opts[@]}" 2>&1 >/dev/null)"
+      command_err="$(git "${git_config[@]}" $git_command_name --skip "${command_opts[@]}" 3>&1 2>&1 >/dev/null)"
       command_result=$?
 
       local todo_parts


### PR DESCRIPTION
…o `/dev/null` and opening editor on `stdout`